### PR TITLE
feat: google oauth integration

### DIFF
--- a/src/lib/styles/stylesheet.css
+++ b/src/lib/styles/stylesheet.css
@@ -142,6 +142,43 @@ body {
   opacity: 0.7;
 }
 
+.btn-google {
+  margin-top: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  font: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.625rem;
+  width: 100%;
+  border: 1px solid #dadce0;
+  background: #ffffff;
+  color: #3c4043;
+  border-radius: 4px;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.btn-google:hover:not(:disabled) {
+  background: var(--background);
+  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.15);
+}
+
+.btn-google:active:not(:disabled) {
+  background: #f1f3f4;
+}
+
+.btn-google:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.btn-google__icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
 .auth-switch {
   margin: 1rem 0 0;
   font-size: 0.875rem;

--- a/src/lib/styles/stylesheet.sass
+++ b/src/lib/styles/stylesheet.sass
@@ -123,6 +123,38 @@ body
     cursor: not-allowed
     opacity: 0.7
 
+.btn-google
+    margin-top: 0.5rem
+    padding: 0.55rem 0.75rem
+    font: inherit
+    cursor: pointer
+    display: flex
+    align-items: center
+    justify-content: center
+    gap: 0.625rem
+    width: 100%
+    border: 1px solid #dadce0
+    background: #ffffff
+    color: #3c4043
+    border-radius: 4px
+    transition: background-color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease
+
+.btn-google:hover:not(:disabled)
+    background: var(--background)
+    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.15)
+
+.btn-google:active:not(:disabled)
+    background: #f1f3f4
+
+.btn-google:disabled
+    cursor: not-allowed
+    opacity: 0.7
+
+.btn-google__icon
+    width: 18px
+    height: 18px
+    flex-shrink: 0
+
 .auth-switch
     margin: 1rem 0 0
     font-size: 0.875rem

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,4 +1,3 @@
-import { redirect } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ url, locals }) => {
@@ -8,9 +7,15 @@ export const GET: RequestHandler = async ({ url, locals }) => {
   if (code) {
     const { error } = await locals.supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      redirect(303, next);
+      return new Response(null, {
+        status: 303,
+        headers: { location: next },
+      });
     }
   }
 
-  redirect(303, "/login?error=oauth");
+  return new Response(null, {
+    status: 303,
+    headers: { location: "/login?error=oauth" },
+  });
 };

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -1,0 +1,16 @@
+import { redirect } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+  const code = url.searchParams.get("code");
+  const next = url.searchParams.get("next") ?? "/";
+
+  if (code) {
+    const { error } = await locals.supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      redirect(303, next);
+    }
+  }
+
+  redirect(303, "/login?error=oauth");
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -27,6 +27,25 @@
     }
   }
 
+  async function signInWithGoogle() {
+    resetMessages()
+    loading = true
+
+    const supabase = page.data.supabase
+
+    const { error: err } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+
+    if (err) {
+      loading = false
+      error = err.message
+    }
+  }
+
   async function submit(e: SubmitEvent) {
     e.preventDefault()
     resetMessages()
@@ -201,6 +220,39 @@
         {loading ? 'Please wait…' : mode === 'signin' ? 'Sign in' : 'Sign up'}
       </button>
     </form>
+
+    <button
+      type="button"
+      class="btn-google"
+      onclick={signInWithGoogle}
+      disabled={loading}
+    >
+      <svg
+        class="btn-google__icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 48 48"
+        aria-hidden="true"
+      >
+        <path
+          fill="#EA4335"
+          d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+        />
+        <path
+          fill="#4285F4"
+          d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+        />
+        <path
+          fill="#34A853"
+          d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+        />
+        <path fill="none" d="M0 0h48v48H0z" />
+      </svg>
+      Continue with Google
+    </button>
 
     <p class="auth-switch">
       {mode === 'signin' ? 'No account yet?' : 'Already have an account?'}


### PR DESCRIPTION
## Related Issue / User Story and BRIEFLY explain what you have done/changed and where

Link the issue or user story this PR belongs to:

- Closes #33 

---

Added Google OAuth as a sign-in option on the login page.
- `src/routes/login/+page.svelte`: added `signInWithGoogle` which calls `supabase.auth.signInWithOAuth` with `${window.location.origin}/auth/callback` as the redirect URL. Added a "Continue with Google" button styled with Google's branded look (white background, official multi-color "G" logo) while keeping the project's Cascadia Mono font and theme.
- `src/routes/auth/callback/+server.ts`: new server route that handles the OAuth handshake. Exchanges the `code` query param for a session via `exchangeCodeForSession` and redirects to `/` on success, or back to `/login?error=oauth` on failure.
- `src/lib/styles/stylesheet.sass` + `stylesheet.css`: added `.btn-google` styles with hover state using the page `--background` color so it blends with the overall theme.


## Type of change

- [ ] New feature (User Story implementation)
- [x] Task (part of a user story)
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update

---

## Tested?

- [x] npm run build passes
- [x] npm run typecheck passes
- [x] npm run format:check passes
- [x] Manual testing done locally

## Notes:

---

## Checklist before requesting review

- [x] Code follows project style (Prettier)
- [x] No TypeScript errors
- [x] CI passes locally (build + typecheck)
- [x] Linked to issue / user story
- [x] Small, focused PR (not multiple features)

---

## Notes for reviewers

Anything reviewers should focus on:

-