### PR TITLE
feat(notifications): add realtime alerts with toasts and inbox badge

### DIFF
--- a/src/lib/components/AlertsListener.svelte
+++ b/src/lib/components/AlertsListener.svelte
@@ -1,0 +1,299 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte'
+  import { page } from '$app/stores'
+  import { goto } from '$app/navigation'
+  import { fly, fade } from 'svelte/transition'
+  import type { SupabaseClient } from '@supabase/supabase-js'
+  import { unreadAlerts } from '$lib/stores/alerts.svelte'
+
+  type Toast = {
+    id: string
+    title: string
+    body: string
+  }
+
+  const TOAST_DURATION_MS = 6000
+
+  let { supabase, initialUnread }: {
+    supabase: SupabaseClient
+    initialUnread: number
+  } = $props()
+
+  let toasts = $state<Toast[]>([])
+
+  $effect(() => {
+    unreadAlerts.set(initialUnread)
+  })
+
+  /*
+    When a new alert row appears we don't yet have the joined product
+    info, so do a small follow-up fetch for just that row. Cheap and
+    keeps the realtime payload size small.
+  */
+  async function fetchAlertDetail(id: string) {
+    const { data } = await supabase
+      .from('alerts')
+      .select(
+        'id, alert_type, last_triggered_at, shelf_items(barcode, expiry_date, product_catalog(product_name))',
+      )
+      .eq('id', id)
+      .maybeSingle()
+    return data
+  }
+
+  function buildMessage(row: any) {
+    const shelf = Array.isArray(row.shelf_items)
+      ? row.shelf_items[0]
+      : row.shelf_items
+    if (!shelf) return { title: row.alert_type, body: '' }
+
+    const product = Array.isArray(shelf.product_catalog)
+      ? shelf.product_catalog[0]
+      : shelf.product_catalog
+    const name = product?.product_name || shelf.barcode || 'Item'
+
+    if (row.alert_type === 'LOWSTOCK') {
+      return { title: 'Running low', body: name + ' is running low' }
+    }
+
+    if (!shelf.expiry_date) return { title: 'Expiring soon', body: name }
+
+    const today = new Date(new Date().toISOString().split('T')[0]).getTime()
+    const diff = Math.ceil(
+      (new Date(shelf.expiry_date).getTime() - today) / 86400000,
+    )
+    const status =
+      diff < 0
+        ? 'has expired'
+        : diff === 0
+          ? 'expires today'
+          : 'expires in ' + diff + ' day' + (diff === 1 ? '' : 's')
+    return { title: 'Expiry alert', body: name + ' ' + status }
+  }
+
+  function pushToast(id: string, title: string, body: string) {
+    toasts = [...toasts, { id, title, body }]
+  }
+
+  function dismissToast(id: string) {
+    toasts = toasts.filter((x) => x.id !== id)
+  }
+
+  function openInbox(id: string) {
+    dismissToast(id)
+    goto('/inbox')
+  }
+
+  let channel: ReturnType<typeof supabase.channel> | undefined
+
+  onMount(() => {
+    channel = supabase
+      .channel('alerts-global')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'alerts' },
+        async (payload) => {
+          const row = payload.new as {
+            id: string
+            resolved_at: string | null
+            read_at: string | null
+          }
+          if (row.resolved_at || row.read_at) return
+
+          unreadAlerts.increment()
+
+          /*
+            Suppress the toast if the user is already on /inbox —
+            the inbox UI shows the alert directly.
+          */
+          if ($page.url.pathname === '/inbox') return
+
+          const detail = await fetchAlertDetail(row.id)
+          if (!detail) return
+          const { title, body } = buildMessage(detail)
+          pushToast(row.id, title, body)
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'alerts' },
+        (payload) => {
+          const row = payload.new as {
+            id: string
+            read_at: string | null
+            resolved_at: string | null
+          }
+          const old = payload.old as {
+            read_at?: string | null
+            resolved_at?: string | null
+          }
+
+          /*
+            Decrement when an alert that was unread+unresolved
+            transitions out of that state (either marked read or
+            resolved).
+          */
+          const wasUnread = !old?.read_at && !old?.resolved_at
+          const nowCounted = !row.read_at && !row.resolved_at
+          if (wasUnread && !nowCounted) {
+            unreadAlerts.decrement()
+            dismissToast(row.id)
+          } else if (!wasUnread && nowCounted) {
+            unreadAlerts.increment()
+          }
+        },
+      )
+      .subscribe()
+  })
+
+  onDestroy(() => {
+    if (channel) channel.unsubscribe()
+  })
+</script>
+
+<div class="toast-stack" aria-live="polite" aria-atomic="false">
+  {#each toasts as t (t.id)}
+    <div
+      class="toast"
+      role="status"
+      in:fly={{ y: -16, duration: 220 }}
+      out:fade={{ duration: 160 }}
+    >
+      <div class="toast__row">
+        <button
+          type="button"
+          class="toast__main"
+          onclick={() => openInbox(t.id)}
+        >
+          <span class="toast__title">{t.title}</span>
+          <span class="toast__body">{t.body}</span>
+        </button>
+        <button
+          type="button"
+          class="toast__close"
+          aria-label="Dismiss"
+          onclick={() => dismissToast(t.id)}
+        >
+          ×
+        </button>
+      </div>
+      <div
+        class="toast__bar"
+        style="animation-duration: {TOAST_DURATION_MS}ms;"
+        onanimationend={() => dismissToast(t.id)}
+        aria-hidden="true"
+      ></div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .toast-stack {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 1000;
+    max-width: calc(100vw - 2rem);
+    width: 320px;
+    pointer-events: none;
+  }
+
+  .toast {
+    pointer-events: auto;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    overflow: hidden;
+    font-family: 'Cascadia Mono', monospace;
+  }
+
+  .toast:hover .toast__bar,
+  .toast:focus-within .toast__bar {
+    animation-play-state: paused;
+  }
+
+  .toast__row {
+    display: flex;
+    align-items: stretch;
+  }
+
+  .toast__bar {
+    height: 2px;
+    background: var(--accent);
+    transform-origin: left center;
+    animation-name: toast-countdown;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+    opacity: 0.55;
+  }
+
+  @keyframes toast-countdown {
+    from {
+      transform: scaleX(1);
+    }
+    to {
+      transform: scaleX(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toast__bar {
+      animation-duration: 8000ms !important;
+    }
+  }
+
+  .toast__main {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: inherit;
+    text-align: left;
+    padding: 0.65rem 0.5rem 0.7rem 0.85rem;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font: inherit;
+  }
+
+  .toast__main:hover {
+    background: var(--background);
+  }
+
+  .toast__title {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.65;
+  }
+
+  .toast__body {
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+
+  .toast__close {
+    background: transparent;
+    border: none;
+    border-left: 1px solid var(--border);
+    color: var(--text);
+    font-family: 'Cascadia Mono', monospace;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 0.75rem;
+    cursor: pointer;
+    opacity: 0.55;
+    transition: opacity 0.15s, background 0.15s;
+  }
+
+  .toast__close:hover {
+    opacity: 1;
+    background: var(--background);
+  }
+</style>

--- a/src/lib/components/AlertsListener.svelte
+++ b/src/lib/components/AlertsListener.svelte
@@ -143,6 +143,28 @@
           }
         },
       )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'alerts' },
+        (payload) => {
+          /*
+            DELETE payload.old only has full columns when the table
+            has REPLICA IDENTITY FULL. With the default we still get
+            the id, so we can always dismiss any visible toast for
+            this alert. We only decrement the badge when we know the
+            row was unread+unresolved.
+          */
+          const old = payload.old as {
+            id?: string
+            read_at?: string | null
+            resolved_at?: string | null
+          }
+          if (!old?.id) return
+          dismissToast(old.id)
+          const wasUnread = !old.read_at && !old.resolved_at
+          if (wasUnread) unreadAlerts.decrement()
+        },
+      )
       .subscribe()
   })
 

--- a/src/lib/components/Menu.svelte
+++ b/src/lib/components/Menu.svelte
@@ -1,17 +1,57 @@
-<script>
+<script lang="ts">
   import {
     IconHome2Filled,
     IconCameraFilled,
     IconBellFilled,
     IconDots,
   } from '@tabler/icons-svelte'
+  import { unreadAlerts } from '$lib/stores/alerts.svelte'
 </script>
 
 <div id="menu">
   <ul>
     <li><a href="/"><IconHome2Filled size={32} /></a></li>
-    <li><a href="/scan-item" data-sveltekit-preload-data="off"><IconCameraFilled size={32} /></a></li>
-    <li><a href="/inbox"><IconBellFilled size={32} /></a></li>
+    <li>
+      <a href="/scan-item" data-sveltekit-preload-data="off">
+        <IconCameraFilled size={32} />
+      </a>
+    </li>
+    <li class="menu__bell">
+      <a href="/inbox" aria-label="Inbox{unreadAlerts.count > 0 ? ', ' + unreadAlerts.count + ' unread' : ''}">
+        <IconBellFilled size={32} />
+        {#if unreadAlerts.count > 0}
+          <span class="menu__badge" aria-hidden="true">
+            {unreadAlerts.count > 99 ? '99+' : unreadAlerts.count}
+          </span>
+        {/if}
+      </a>
+    </li>
     <li><IconDots size={32} /></li>
   </ul>
 </div>
+
+<style>
+  .menu__bell a {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .menu__badge {
+    position: absolute;
+    top: -4px;
+    right: -8px;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 999px;
+    background: var(--error);
+    color: var(--accent-contrast);
+    font-family: 'Cascadia Mono', monospace;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 18px;
+    text-align: center;
+    box-shadow: 0 0 0 2px var(--background);
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/stores/alerts.svelte.ts
+++ b/src/lib/stores/alerts.svelte.ts
@@ -1,0 +1,25 @@
+/*
+  Tiny global state for the unread-alerts badge. The AlertsListener
+  component (mounted in the root layout) is the single writer; any
+  component (e.g. the Menu bell) can read .count for reactive display.
+*/
+function createUnreadAlerts() {
+  let count = $state(0);
+
+  return {
+    get count() {
+      return count;
+    },
+    set(value: number) {
+      count = Math.max(0, value);
+    },
+    increment() {
+      count += 1;
+    },
+    decrement() {
+      count = Math.max(0, count - 1);
+    },
+  };
+}
+
+export const unreadAlerts = createUnreadAlerts();

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -17,7 +17,23 @@ export const load: LayoutServerLoad = async ({ cookies, locals, url }) => {
     redirect(303, "/");
   }
 
+  let unreadAlertCount = 0;
+  if (user) {
+    const { count, error } = await locals.supabase
+      .from("alerts")
+      .select("id", { count: "exact", head: true })
+      .is("resolved_at", null)
+      .is("read_at", null);
+
+    if (error) {
+      console.error("[layout] failed to count unread alerts", error);
+    } else {
+      unreadAlertCount = count ?? 0;
+    }
+  }
+
   return {
     cookies: cookies.getAll(),
+    unreadAlertCount,
   };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,9 +6,10 @@
 
   import Navbar from '$lib/components/Navbar.svelte'
   import Menu from '$lib/components/Menu.svelte'
+  import AlertsListener from '$lib/components/AlertsListener.svelte'
 
   let { data, children } = $props()
-  let { supabase, claims } = $derived(data)
+  let { supabase, claims, unreadAlertCount } = $derived(data)
 
   onMount(() => {
     const { data } = supabase.auth.onAuthStateChange((event, _session) => {
@@ -29,3 +30,7 @@
 {@render children()}
 
 <Menu />
+
+{#if claims}
+  <AlertsListener {supabase} initialUnread={unreadAlertCount ?? 0} />
+{/if}

--- a/src/routes/inbox/+page.server.ts
+++ b/src/routes/inbox/+page.server.ts
@@ -1,88 +1,118 @@
-import { supabase } from "$lib/supabaseClient";
+import { fail, type Actions } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
 
-export async function load() {
-  const now = new Date();
-  const todayISO = now.toISOString().split("T")[0];
-  const startOfToday = new Date(todayISO).getTime();
-
-  const [itemsRes, sentTodayRes] = await Promise.all([
-    supabase
-      .from("shelf_items")
-      .select(
-        "id, expiry_date, barcode, current_weight_g, low_stock_threshold_g",
-      ),
-    supabase
-      .from("alerts")
-      .select("item_id, alert_type")
-      .gte("last_triggered_at", todayISO),
-  ]);
-
-  const sentToday = new Set(
-    (sentTodayRes.data ?? []).map(function (s) {
-      return s.item_id + "-" + s.alert_type;
-    }),
-  );
-
-  const toInsert: {
-    item_id: string;
-    alert_type: string;
-    last_triggered_at: string;
-  }[] = [];
-  (itemsRes.data ?? []).forEach(function (item) {
-    if (item.expiry_date) {
-      const diff = Math.ceil(
-        (new Date(item.expiry_date).getTime() - startOfToday) / 86400000,
-      );
-      if (diff <= 2 && !sentToday.has(item.id + "-EXPIRY")) {
-        toInsert.push({
-          item_id: item.id,
-          alert_type: "EXPIRY",
-          last_triggered_at: now.toISOString(),
-        });
+type AlertRow = {
+  id: string;
+  alert_type: string;
+  last_triggered_at: string | null;
+  read_at: string | null;
+  shelf_items:
+    | {
+        barcode: string | null;
+        expiry_date: string | null;
+        product_catalog:
+          | { product_name: string | null }
+          | { product_name: string | null }[]
+          | null;
       }
-    }
+    | {
+        barcode: string | null;
+        expiry_date: string | null;
+        product_catalog:
+          | { product_name: string | null }
+          | { product_name: string | null }[]
+          | null;
+      }[]
+    | null;
+};
 
-    if (
-      item.current_weight_g <= item.low_stock_threshold_g &&
-      !sentToday.has(item.id + "-LOWSTOCK")
-    ) {
-      toInsert.push({
-        item_id: item.id,
-        alert_type: "LOWSTOCK",
-        last_triggered_at: now.toISOString(),
-      });
-    }
-  });
+export const load: PageServerLoad = async ({ locals, depends }) => {
+  depends("app:alerts");
 
-  if (toInsert.length > 0) await supabase.from("alerts").insert(toInsert);
+  const startOfToday = new Date(
+    new Date().toISOString().split("T")[0],
+  ).getTime();
 
-  const { data: alerts } = await supabase
+  const { data, error } = await locals.supabase
     .from("alerts")
     .select(
-      "*, shelf_items(barcode, expiry_date, product_catalog(product_name))",
+      "id, alert_type, last_triggered_at, read_at, shelf_items(barcode, expiry_date, product_catalog(product_name))",
     )
+    .is("resolved_at", null)
     .order("last_triggered_at", { ascending: false });
 
+  if (error) {
+    console.error("[inbox] failed to load alerts", error);
+  }
+
+  const rows = (data ?? []) as unknown as AlertRow[];
+
   return {
-    notifications: (alerts ?? []).map(function (n: any) {
-      return {
-        id: n.id,
-        message: formatMessage(n, startOfToday),
-        timestamp: formatRelative(n.last_triggered_at),
-      };
-    }),
+    notifications: rows.map((n) => ({
+      id: n.id,
+      alertType: n.alert_type,
+      lastTriggeredAt: n.last_triggered_at,
+      readAt: n.read_at,
+      message: formatMessage(n, startOfToday),
+    })),
   };
+};
+
+export const actions: Actions = {
+  markRead: async ({ request, locals }) => {
+    const form = await request.formData();
+    const id = form.get("id");
+    if (typeof id !== "string" || !id) {
+      return fail(400, { message: "Missing alert id" });
+    }
+
+    const { error } = await locals.supabase
+      .from("alerts")
+      .update({ read_at: new Date().toISOString() })
+      .eq("id", id)
+      .is("read_at", null);
+
+    if (error) {
+      console.error("[inbox] failed to mark alert read", error);
+      return fail(500, { message: "Could not mark notification as read" });
+    }
+
+    return { success: true };
+  },
+
+  markAllRead: async ({ locals }) => {
+    const { error } = await locals.supabase
+      .from("alerts")
+      .update({ read_at: new Date().toISOString() })
+      .is("read_at", null)
+      .is("resolved_at", null);
+
+    if (error) {
+      console.error("[inbox] failed to mark all alerts read", error);
+      return fail(500, { message: "Could not mark notifications as read" });
+    }
+
+    return { success: true };
+  },
+};
+
+function firstOrNull<T>(value: T | T[] | null | undefined): T | null {
+  if (!value) return null;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
 }
 
-function formatMessage(n: any, startOfToday: number) {
-  const shelf = n.shelf_items;
+function formatMessage(n: AlertRow, startOfToday: number) {
+  const shelf = firstOrNull(n.shelf_items);
   if (!shelf) return n.alert_type;
 
-  const name = shelf.product_catalog?.product_name || shelf.barcode;
+  const product = firstOrNull(shelf.product_catalog);
+  const name = product?.product_name || shelf.barcode || "Item";
 
   if (n.alert_type === "LOWSTOCK") {
     return name + " is running low";
   }
+
+  if (!shelf.expiry_date) return name;
 
   const diff = Math.ceil(
     (new Date(shelf.expiry_date).getTime() - startOfToday) / 86400000,
@@ -94,15 +124,4 @@ function formatMessage(n: any, startOfToday: number) {
         ? "expires today"
         : "expires in " + diff + " day(s)";
   return name + " " + status;
-}
-
-function formatRelative(dateStr: string) {
-  if (!dateStr) return "Unknown date";
-  const delta = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-  if (delta < 60) return "just now";
-  const mins = Math.floor(delta / 60);
-  if (mins < 60) return mins + " minutes ago";
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return hours + " hours ago";
-  return new Date(dateStr).toLocaleDateString();
 }

--- a/src/routes/inbox/+page.svelte
+++ b/src/routes/inbox/+page.svelte
@@ -1,21 +1,370 @@
 <script lang="ts">
-  let { data } = $props();
+  import { onMount, onDestroy, untrack } from 'svelte'
+  import { invalidate } from '$app/navigation'
+  import { enhance } from '$app/forms'
+  import { fly, slide } from 'svelte/transition'
+  import { flip } from 'svelte/animate'
+  import { quintOut } from 'svelte/easing'
+  import type { PageData } from './$types'
+
+  let { data }: { data: PageData } = $props()
+
+  type Notification = PageData['notifications'][number]
+
+  /*
+    Local mirror of the server-provided list so we can patch it from
+    realtime payloads (cron inserts, mark-read updates, resolutions)
+    without re-running the server load on every event.
+  */
+  let liveById = $state<Record<string, Notification>>({})
+
+  $effect(() => {
+    const incoming = data.notifications
+    untrack(() => {
+      const next: Record<string, Notification> = {}
+      for (const n of incoming) {
+        const existing = liveById[n.id]
+        if (existing && existing.readAt && !n.readAt) {
+          next[n.id] = { ...n, readAt: existing.readAt }
+        } else {
+          next[n.id] = n
+        }
+      }
+      liveById = next
+    })
+  })
+
+  let now = $state(Date.now())
+  let tick: ReturnType<typeof setInterval> | undefined
+  let mounted = $state(false)
+  onMount(() => {
+    tick = setInterval(() => (now = Date.now()), 15_000)
+    /*
+      Defer enabling entry transitions by one tick so the initial
+      list doesn't fly in on first paint — only newly-arriving rows
+      after mount should animate.
+    */
+    queueMicrotask(() => (mounted = true))
+  })
+
+  const list = $derived(
+    Object.values(liveById).sort((a, b) => {
+      const at = a.lastTriggeredAt ? new Date(a.lastTriggeredAt).getTime() : 0
+      const bt = b.lastTriggeredAt ? new Date(b.lastTriggeredAt).getTime() : 0
+      return bt - at
+    }),
+  )
+
+  const unreadCount = $derived(list.filter((n) => !n.readAt).length)
+
+  function formatRelative(dateStr: string | null, nowMs: number) {
+    if (!dateStr) return ''
+    const delta = Math.floor((nowMs - new Date(dateStr).getTime()) / 1000)
+    if (delta < 60) return 'just now'
+    const mins = Math.floor(delta / 60)
+    if (mins < 60) return mins + ' minute' + (mins === 1 ? '' : 's') + ' ago'
+    const hours = Math.floor(mins / 60)
+    if (hours < 24) return hours + ' hour' + (hours === 1 ? '' : 's') + ' ago'
+    return new Date(dateStr).toLocaleDateString()
+  }
+
+  let invalidateTimer: ReturnType<typeof setTimeout> | undefined
+  function scheduleRefresh() {
+    if (invalidateTimer) return
+    invalidateTimer = setTimeout(() => {
+      invalidateTimer = undefined
+      invalidate('app:alerts')
+    }, 30_000)
+  }
+
+  let channel: ReturnType<typeof data.supabase.channel> | undefined
+
+  onMount(() => {
+    channel = data.supabase
+      .channel('inbox-live')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'alerts' },
+        (payload) => {
+          const row = payload.new as {
+            id: string
+            resolved_at: string | null
+          }
+          if (row.resolved_at) return
+          /*
+            New row from cron — we don't have the joined product info
+            yet, so fall back to a refresh. Cheap because it only fires
+            when an alert actually appears.
+          */
+          scheduleRefresh()
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'alerts' },
+        (payload) => {
+          const row = payload.new as {
+            id: string
+            read_at: string | null
+            resolved_at: string | null
+          }
+          const existing = liveById[row.id]
+          if (!existing) return
+          if (row.resolved_at) {
+            const { [row.id]: _, ...rest } = liveById
+            liveById = rest
+            return
+          }
+          if (row.read_at !== existing.readAt) {
+            liveById = {
+              ...liveById,
+              [row.id]: { ...existing, readAt: row.read_at },
+            }
+          }
+        },
+      )
+      .subscribe()
+  })
+
+  onDestroy(() => {
+    if (tick) clearInterval(tick)
+    if (invalidateTimer) clearTimeout(invalidateTimer)
+    if (channel) channel.unsubscribe()
+  })
+
+  function markReadLocal(id: string) {
+    const existing = liveById[id]
+    if (!existing || existing.readAt) return
+    liveById = {
+      ...liveById,
+      [id]: { ...existing, readAt: new Date().toISOString() },
+    }
+  }
 </script>
 
-<h1>Inbox</h1>
-<button
-  onclick={function () {
-    history.back();
-  }}>Back</button
->
+<svelte:head>
+  <title>inbox · shelfAware</title>
+</svelte:head>
 
-<ul>
-  {#each data.notifications as n}
-    <li>
-      <strong>{n.message}</strong>
-      <p>{n.timestamp}</p>
-    </li>
+<main class="inbox">
+  <header class="inbox__header">
+    <button
+      type="button"
+      class="inbox__back"
+      onclick={() => history.back()}
+      aria-label="Go back"
+    >
+      ←
+    </button>
+    <h1>Inbox</h1>
+    {#if unreadCount > 0}
+      <form
+        method="POST"
+        action="?/markAllRead"
+        use:enhance={() => {
+          for (const id of Object.keys(liveById)) markReadLocal(id)
+          return async ({ update }) => {
+            await update({ reset: false })
+          }
+        }}
+      >
+        <button type="submit" class="inbox__mark-all">Mark all read</button>
+      </form>
+    {/if}
+  </header>
+
+  {#if list.length === 0}
+    <p class="inbox__empty">You're all caught up.</p>
   {:else}
-    <p>No notifications found.</p>
-  {/each}
-</ul>
+    <ul class="inbox__list">
+      {#each list as n (n.id)}
+        <li
+          class="inbox-item"
+          class:inbox-item--unread={!n.readAt}
+          in:fly|global={{
+            y: -8,
+            duration: mounted ? 280 : 0,
+            easing: quintOut,
+          }}
+          out:slide={{ duration: 220, easing: quintOut }}
+          animate:flip={{ duration: 320, easing: quintOut }}
+        >
+          <form
+            method="POST"
+            action="?/markRead"
+            use:enhance={() => {
+              markReadLocal(n.id)
+              return async ({ update }) => {
+                await update({ reset: false })
+              }
+            }}
+          >
+            <input type="hidden" name="id" value={n.id} />
+            <button type="submit" class="inbox-item__btn">
+              <span class="inbox-item__dot" aria-hidden="true"></span>
+              <span class="inbox-item__body">
+                <span class="inbox-item__message">{n.message}</span>
+                <span class="inbox-item__meta">
+                  <span class="inbox-item__type">{n.alertType}</span>
+                  <span class="inbox-item__sep">·</span>
+                  <span class="inbox-item__time">
+                    {formatRelative(n.lastTriggeredAt, now)}
+                  </span>
+                </span>
+              </span>
+            </button>
+          </form>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</main>
+
+<style>
+  .inbox {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 1.5rem 1rem 8rem;
+  }
+
+  .inbox__header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .inbox__header h1 {
+    flex: 1;
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 500;
+  }
+
+  .inbox__back {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    width: 2.25rem;
+    height: 2.25rem;
+    font: inherit;
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .inbox__back:hover {
+    background: var(--background);
+  }
+
+  .inbox__mark-all {
+    background: transparent;
+    border: none;
+    font: inherit;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    opacity: 0.75;
+  }
+
+  .inbox__mark-all:hover {
+    opacity: 1;
+  }
+
+  .inbox__empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    opacity: 0.6;
+    font-size: 0.9rem;
+  }
+
+  .inbox__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .inbox-item {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    transition:
+      background 0.15s,
+      border-color 0.15s;
+  }
+
+  .inbox-item--unread {
+    border-left: 3px solid var(--accent);
+  }
+
+  .inbox-item--unread .inbox-item__dot {
+    background: var(--accent);
+  }
+
+  .inbox-item--unread .inbox-item__message {
+    font-weight: 600;
+  }
+
+  .inbox-item__btn {
+    width: 100%;
+    background: transparent;
+    border: none;
+    padding: 0.85rem 1rem;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+  }
+
+  .inbox-item__btn:hover {
+    background: var(--background);
+  }
+
+  .inbox-item__dot {
+    flex-shrink: 0;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: transparent;
+    margin-top: 0.5rem;
+  }
+
+  .inbox-item__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .inbox-item__message {
+    line-height: 1.4;
+    font-size: 0.95rem;
+  }
+
+  .inbox-item__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+    opacity: 0.55;
+  }
+
+  .inbox-item__type {
+    text-transform: lowercase;
+    letter-spacing: 0.04em;
+  }
+
+  .inbox-item__sep {
+    opacity: 0.6;
+  }
+</style>

--- a/src/routes/inbox/+page.svelte
+++ b/src/routes/inbox/+page.svelte
@@ -123,6 +123,16 @@
           }
         },
       )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'alerts' },
+        (payload) => {
+          const old = payload.old as { id?: string }
+          if (!old?.id || !(old.id in liveById)) return
+          const { [old.id]: _, ...rest } = liveById
+          liveById = rest
+        },
+      )
       .subscribe()
   })
 


### PR DESCRIPTION
## Related Issue / User Story and BRIEFLY explain what you have done/changed and where

Link the issue or user story this PR belongs to:

- Related to US - #4

---- 

Move alert generation off the inbox `load` and onto a scheduled `pg_cron` job (`public.generate_alerts()`) that both inserts new alerts and auto-resolves stale ones. Rebuild the frontend around the new flow:

- `src/routes/inbox/+page.server.ts` - pure read using `event.locals.supabase` (RLS-aware), with `markRead` / `markAllRead` form actions and `depends("app:alerts")`.
- `src/routes/inbox/+page.svelte` - realtime subscription on `alerts` (INSERT/UPDATE), unread styling, optimistic mark-as-read, live relative timestamps, and `fly`/`slide`/`flip` animations for arriving and dismissed alerts.
- `src/lib/components/AlertsListener.svelte` - new global component mounted in the root layout that shows top-right toasts for new alerts, with a countdown progress bar (pause on hover) styled to the site palette. Suppresses toasts when already on `/inbox`.
- `src/lib/components/Menu.svelte` - iOS-style unread badge on the bell icon.
- `src/lib/stores/alerts.svelte.ts` - small `$state` store keeping the unread count in sync between layout-server hydrate and realtime events.
- `src/routes/+layout.server.ts` / `+layout.svelte` - count unread alerts per request to hydrate the badge, mount the listener for signed-in users.

---

## Type of change

- [x] New feature (User Story implementation)
- [x] Task (part of a user story)
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update

---

## Tested?

- [x] npm run build passes
- [x] npm run typecheck passes
- [x] npm run format:check passes
- [x] Manual testing done locally

## Notes:

Manual smoke tests:
- Forced LOWSTOCK / EXPIRY conditions on a `shelf_items` row, ran `select public.generate_alerts();` and confirmed alerts appear in the inbox within ~60 s, toast pops in top-right, bell badge increments.
- Marked alerts read from inbox → badge decrements, toast for that alert is dismissed if visible, value persists in DB.
- Reversed the underlying condition (restocked / pushed expiry out) → cron auto-resolves the alert, row vanishes from inbox without refresh, badge decrements.
- Re-triggered same-day after resolution → new alert row appears as expected.

---

## Checklist before requesting review

- [x] Code follows project style (Prettier)
- [x] No TypeScript errors
- [x] CI passes locally (build + typecheck)
- [x] Linked to issue / user story
- [x] Small, focused PR (not multiple features)

---

## Notes for reviewers

Anything reviewers should focus on:

- The inbox `load` no longer writes - all inserts are owned by the cron job. Make sure that mental model holds when reading the diff.
- `AlertsListener` is mounted in `+layout.svelte` but gated on `claims` so we don't subscribe on the login page.
- Toast dismissal is driven by the CSS countdown bar's `animationend` event (pauses on hover via `animation-play-state`), not a JS timer - single source of truth between the visual and the actual close.
- Unread count is hydrated server-side on every navigation, then maintained client-side by the realtime UPDATE handler. Worth sanity-checking the increment/decrement logic in `AlertsListener.svelte` (specifically the `wasUnread` / `nowCounted` transitions).